### PR TITLE
イベント発火時にreact-rndのpositionなどを取得できるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^16.11.1",
     "@types/react": "^17.0.30",
     "@types/react-dom": "^17.0.9",
+    "@types/react-rnd": "^8.0.0",
     "@types/styled-components": "^5.1.15",
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",

--- a/src/components/organisms/ReactRndWindow.tsx
+++ b/src/components/organisms/ReactRndWindow.tsx
@@ -8,11 +8,19 @@ type Props = {
   className?: string;
   children?: React.ReactNode;
   options: ReactRndWindowOption;
+  onResizeStop?: (e: MouseEvent) => void;
+  onDragStop?: (e: MouseEvent) => void;
 };
 
 const Root = styled(Rnd)``;
 
-const ReactRndWindow: React.VFC<Props> = ({ children, options, className }) => {
+const ReactRndWindow: React.VFC<Props> = ({
+  children,
+  options,
+  className,
+  onResizeStop,
+  onDragStop,
+}) => {
   return (
     <Root
       className={classes(className)}
@@ -25,6 +33,8 @@ const ReactRndWindow: React.VFC<Props> = ({ children, options, className }) => {
       minWidth={options.minimumSize.x}
       minHeight={options.minimumSize.y}
       bounds="parent"
+      onResizeStop={onResizeStop}
+      onDragStop={onDragStop}
     >
       {children}
     </Root>

--- a/src/components/organisms/ReactRndWindow.tsx
+++ b/src/components/organisms/ReactRndWindow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Rnd } from 'react-rnd';
 import styled from 'styled-components';
+import { Matrix } from '../../types';
 import { ReactRndWindowOption } from '../../types/reactRndWindow';
 import { classes } from '../../utils/classes';
 
@@ -8,8 +9,12 @@ type Props = {
   className?: string;
   children?: React.ReactNode;
   options: ReactRndWindowOption;
-  onResizeStop?: (e: MouseEvent) => void;
-  onDragStop?: (e: MouseEvent) => void;
+  size: Matrix;
+  position: Matrix;
+  onResizeStart: (e: MouseEvent) => void;
+  onResizeStop: (e: MouseEvent) => void;
+  onDragStart: (e: MouseEvent) => void;
+  onDragStop: (e: MouseEvent) => void;
 };
 
 const Root = styled(Rnd)``;
@@ -18,7 +23,11 @@ const ReactRndWindow: React.VFC<Props> = ({
   children,
   options,
   className,
+  size,
+  position,
+  onResizeStart,
   onResizeStop,
+  onDragStart,
   onDragStop,
 }) => {
   return (
@@ -30,10 +39,14 @@ const ReactRndWindow: React.VFC<Props> = ({
         width: options.initialSize.x,
         height: options.initialSize.y,
       }}
+      size={size}
+      position={position}
       minWidth={options.minimumSize.x}
       minHeight={options.minimumSize.y}
       bounds="parent"
+      onResizeStart={onResizeStart}
       onResizeStop={onResizeStop}
+      onDragStart={onDragStart}
       onDragStop={onDragStop}
     >
       {children}

--- a/src/components/organisms/StickyNote.tsx
+++ b/src/components/organisms/StickyNote.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Editor, EditorState, RichUtils, DraftEditorCommand } from 'draft-js';
 import { colors } from '../../styles/variables';
 import { ReactRndWindowOption } from '../../types/reactRndWindow';
+import { useRndLayoutProvider } from '../../hooks/reactRnd';
 import ReactRndWindow from './ReactRndWindow';
 
 type Props = {
@@ -14,6 +15,7 @@ const Root = styled(ReactRndWindow)`
 `;
 
 const StickyNote: React.VFC<Props> = ({ options }) => {
+  const rndLayoutProvider = useRndLayoutProvider(options);
   const [editorState, setEditorState] = useState(EditorState.createEmpty());
 
   const handleKeyCommand = (command: DraftEditorCommand) => {
@@ -25,22 +27,18 @@ const StickyNote: React.VFC<Props> = ({ options }) => {
     return 'not-handled';
   };
 
-  const onResizeStop = (e: MouseEvent) => {
-    console.log(e);
-  };
-
-  const onDragStop = (e: MouseEvent) => {
-    console.log(e);
-  };
-
   if (process.browser === false) {
     return null;
   }
   return (
     <Root
       options={options}
-      onResizeStop={e => onResizeStop(e)}
-      onDragStop={e => onDragStop(e)}
+      size={rndLayoutProvider.size}
+      position={rndLayoutProvider.position}
+      onResizeStart={e => rndLayoutProvider.onResizeStart(e)}
+      onResizeStop={e => rndLayoutProvider.onResizeStop(e)}
+      onDragStart={e => rndLayoutProvider.onDragStart(e)}
+      onDragStop={e => rndLayoutProvider.onDragStop(e)}
     >
       <Editor
         editorState={editorState}

--- a/src/components/organisms/StickyNote.tsx
+++ b/src/components/organisms/StickyNote.tsx
@@ -5,6 +5,7 @@ import { colors } from '../../styles/variables';
 import { ReactRndWindowOption } from '../../types/reactRndWindow';
 import { useRndLayoutProvider } from '../../hooks/reactRnd';
 import ReactRndWindow from './ReactRndWindow';
+import 'draft-js/dist/Draft.css';
 
 type Props = {
   options: ReactRndWindowOption;

--- a/src/components/organisms/StickyNote.tsx
+++ b/src/components/organisms/StickyNote.tsx
@@ -1,16 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Editor, EditorState, RichUtils, DraftEditorCommand } from 'draft-js';
 import { colors } from '../../styles/variables';
 import { ReactRndWindowOption } from '../../types/reactRndWindow';
 import ReactRndWindow from './ReactRndWindow';
-import 'draft-js/dist/Draft.css';
-
-// This is experimental implementation.
-// TODO: improve
 
 type Props = {
-  children?: React.ReactNode;
   options: ReactRndWindowOption;
 };
 
@@ -18,7 +13,7 @@ const Root = styled(ReactRndWindow)`
   border: 1px solid ${colors.borderBlack};
 `;
 
-const ExampleStickyNote: React.VFC<Props> = ({ options, children }) => {
+const StickyNote: React.VFC<Props> = ({ options }) => {
   const [editorState, setEditorState] = useState(EditorState.createEmpty());
 
   const handleKeyCommand = (command: DraftEditorCommand) => {
@@ -30,11 +25,23 @@ const ExampleStickyNote: React.VFC<Props> = ({ options, children }) => {
     return 'not-handled';
   };
 
+  const onResizeStop = (e: MouseEvent) => {
+    console.log(e);
+  };
+
+  const onDragStop = (e: MouseEvent) => {
+    console.log(e);
+  };
+
   if (process.browser === false) {
     return null;
   }
   return (
-    <Root options={options}>
+    <Root
+      options={options}
+      onResizeStop={e => onResizeStop(e)}
+      onDragStop={e => onDragStop(e)}
+    >
       <Editor
         editorState={editorState}
         onChange={setEditorState}
@@ -44,4 +51,4 @@ const ExampleStickyNote: React.VFC<Props> = ({ options, children }) => {
   );
 };
 
-export default ExampleStickyNote;
+export default StickyNote;

--- a/src/components/templates/index.tsx
+++ b/src/components/templates/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { exampleStringState } from '../../recoil/atoms/examples';
-import ExampleStickyNote from '../organisms/ExampleStickyNote';
+import StickyNote from '../organisms/StickyNote';
 import BaseTemplate from './base';
 
 const IndexTemplate: React.VFC = () => {
@@ -10,9 +10,16 @@ const IndexTemplate: React.VFC = () => {
 
   return (
     <BaseTemplate>
-      <ExampleStickyNote
+      <StickyNote
         options={{
           initialPosition: { x: 128, y: 128 },
+          initialSize: { x: 320, y: 240 },
+          minimumSize: { x: 320, y: 240 },
+        }}
+      />
+      <StickyNote
+        options={{
+          initialPosition: { x: 0, y: 0 },
           initialSize: { x: 320, y: 240 },
           minimumSize: { x: 320, y: 240 },
         }}

--- a/src/hooks/reactRnd.ts
+++ b/src/hooks/reactRnd.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import { Matrix } from '../types';
+import { ReactRndWindowOption } from '../types/reactRndWindow';
+import { isAvailableWindow } from '../utils/window';
+
+export const useRndLayoutProvider = (options: ReactRndWindowOption) => {
+  const [size, setSize] = useState<Matrix>({
+    x: options.initialSize.x,
+    y: options.initialSize.y,
+  });
+  const [position, setPosition] = useState<Matrix>({
+    x: options.initialPosition.x,
+    y: options.initialPosition.y,
+  });
+  const [mousedownPosition, setMousedownPosition] = useState<Matrix | null>(
+    null,
+  );
+
+  useEffect(() => {
+    console.log(size);
+    console.log(position);
+  }, [size, position]);
+
+  const onDragStart = (e: MouseEvent) => {
+    setMousedownPosition({
+      x: e.pageX,
+      y: e.pageY,
+    });
+  };
+
+  const onDragStop = (e: MouseEvent) => {
+    const innerWidth = isAvailableWindow ? window.innerWidth : 0;
+    const innerHeight = isAvailableWindow ? window.innerHeight : 0;
+
+    const movement: Matrix = {
+      x: e.pageX - mousedownPosition.x,
+      y: e.pageY - mousedownPosition.y,
+    };
+
+    const newPosition: Matrix = {
+      x: position.x + movement.x,
+      y: position.y + movement.y,
+    };
+
+    if (newPosition.x < 0) {
+      newPosition.x = 0;
+    } else if (newPosition.x > innerWidth - size.x) {
+      newPosition.x = innerWidth - size.x;
+    }
+
+    if (newPosition.y < 0) {
+      newPosition.y = 0;
+    } else if (newPosition.y > innerHeight - size.y) {
+      newPosition.y = innerHeight - size.y;
+    }
+
+    setPosition(newPosition);
+  };
+
+  const onResizeStart = (e: MouseEvent) => {
+    setMousedownPosition({
+      x: e.pageX,
+      y: e.pageY,
+    });
+  };
+
+  const onResizeStop = (e: MouseEvent) => {
+    const movement: Matrix = {
+      x: e.pageX - mousedownPosition.x,
+      y: e.pageY - mousedownPosition.y,
+    };
+
+    const newSize: Matrix = {
+      x: size.x + movement.x,
+      y: size.y + movement.y,
+    };
+
+    if (newSize.x < 0) {
+      newSize.x = 0;
+    } else if (newSize.x + position.x > innerWidth) {
+      newSize.x = innerWidth - position.x;
+    }
+
+    if (newSize.y < 0) {
+      newSize.y = 0;
+    } else if (newSize.y + position.y > innerHeight) {
+      newSize.y = innerHeight - position.y;
+    }
+
+    setSize(newSize);
+  };
+
+  return {
+    size,
+    position,
+    onDragStart,
+    onDragStop,
+    onResizeStart,
+    onResizeStop,
+  };
+};

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -34,4 +34,4 @@ export const reactRnd = {
   ReactRnd: {
     borderRadius: '0.5rem',
   },
-};
+} as const;

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-rnd@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-rnd/-/react-rnd-8.0.0.tgz#aec90d5398c83b1c809a5b61a228ae47ac150136"
+  integrity sha512-k/exWCXCY3CDqyJUJeny2SgsfWslWh6XU32/S0YJH6p4E8q2FK89WAPzdG0AECA2k95UC75YKErDRQ/IyvDz6g==
+  dependencies:
+    react-rnd "*"
+
 "@types/react@*", "@types/react@^17.0.30":
   version "17.0.30"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.30.tgz"
@@ -3513,7 +3520,7 @@ react-refresh@0.8.3:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-rnd@^10.3.5:
+react-rnd@*, react-rnd@^10.3.5:
   version "10.3.5"
   resolved "https://registry.npmjs.org/react-rnd/-/react-rnd-10.3.5.tgz"
   integrity sha512-LWJP+l5bp76sDPKrKM8pwGJifI6i3B5jHK4ONACczVMbR8ycNGA75ORRqpRuXGyKawUs68s1od05q8cqWgQXgw==


### PR DESCRIPTION
# issue
resolve #5

# やったこと
- `react-rnd`のsize, position状態管理をhooks化
- StickyNoteのsize, positionをいつでも取得できるように
- StickyNoteがresize, drag時に`innerWidth`, `innerHeight`を超えてはみ出すことがないように修正